### PR TITLE
テーブル定義再定義

### DIFF
--- a/school-timetable-rails/app/controllers/api/v1/timetables_controller.rb
+++ b/school-timetable-rails/app/controllers/api/v1/timetables_controller.rb
@@ -19,8 +19,8 @@ module Api
 
       # POST /api/v1/timetables 対象ユーザに授業を登録する
       def create
-        args = ['insert timetables (user_id,	day_of_week, `time`, period, lecture_id, created_at, updated_at)
-                 select ?, lectures.day_of_week, lectures.`time`, lectures.period, lectures.lecture_id , lectures.created_at, lectures.updated_at from lectures where lecture_id = ?',
+        args = ['insert timetables (user_id,	day_of_week, `time`, period, lecture_id)
+                 select ?, lectures.day_of_week, lectures.`time`, lectures.period, lectures.lecture_id from lectures where lecture_id = ?',
                 params[:user_id], params[:lecture_id]]
         sql = ActiveRecord::Base.send(:sanitize_sql_array, args)
         ActiveRecord::Base.connection.execute(sql)

--- a/school-timetable-rails/db/migrate/20240502113922_create_lectures.rb
+++ b/school-timetable-rails/db/migrate/20240502113922_create_lectures.rb
@@ -14,8 +14,5 @@ class CreateLectures < ActiveRecord::Migration[7.1]
 
       t.timestamps
     end
-
-    # @todo uniqueの制約を持たせたい
-    # add_index :keywords, %i[day_of_week time period teacher_id], unique: true
   end
 end

--- a/school-timetable-rails/db/migrate/20240512044444_remove_date_from_lectures.rb
+++ b/school-timetable-rails/db/migrate/20240512044444_remove_date_from_lectures.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class RemoveDateFromLectures < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :lectures, :created_at, :timestamp
+    remove_column :lectures, :updated_at, :timestamp
+  end
+end

--- a/school-timetable-rails/db/migrate/20240512044705_remove_date_from_teachers.rb
+++ b/school-timetable-rails/db/migrate/20240512044705_remove_date_from_teachers.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class RemoveDateFromTeachers < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :teachers, :created_at, :timestamp
+    remove_column :teachers, :updated_at, :timestamp
+  end
+end

--- a/school-timetable-rails/db/migrate/20240512044748_remove_date_from_timetables.rb
+++ b/school-timetable-rails/db/migrate/20240512044748_remove_date_from_timetables.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class RemoveDateFromTimetables < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :timetables, :created_at, :timestamp
+    remove_column :timetables, :updated_at, :timestamp
+  end
+end

--- a/school-timetable-rails/db/migrate/20240512045721_add_index_lectures.rb
+++ b/school-timetable-rails/db/migrate/20240512045721_add_index_lectures.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddIndexLectures < ActiveRecord::Migration[7.1]
+  def change
+    add_index :lectures, %i[day_of_week time period teacher_id], unique: true
+  end
+end

--- a/school-timetable-rails/db/migrate/20240512045959_add_index_timetables.rb
+++ b/school-timetable-rails/db/migrate/20240512045959_add_index_timetables.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddIndexTimetables < ActiveRecord::Migration[7.1]
+  def change
+    add_index :timetables, %i[day_of_week time period user_id], unique: true
+  end
+end

--- a/school-timetable-rails/db/schema.rb
+++ b/school-timetable-rails/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 20_240_511_032_103) do
+ActiveRecord::Schema[7.1].define(version: 20_240_512_045_959) do
   create_table 'lectures', primary_key: 'lecture_id', charset: 'utf8mb4', collation: 'utf8mb4_0900_ai_ci', force: :cascade do |t|
     t.string 'lecture_name', limit: 60
     t.text 'lecture_overview'
@@ -21,14 +19,11 @@ ActiveRecord::Schema[7.1].define(version: 20_240_511_032_103) do
     t.integer 'time', limit: 2
     t.integer 'period', limit: 1
     t.bigint 'teacher_id'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
+    t.index %w[day_of_week time period teacher_id], name: 'idx_on_day_of_week_time_period_teacher_id_d1e79b0e6a', unique: true
   end
 
   create_table 'teachers', primary_key: 'teacher_id', charset: 'utf8mb4', collation: 'utf8mb4_0900_ai_ci', force: :cascade do |t|
     t.string 'teacher_name', limit: 40
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
   end
 
   create_table 'timetables', id: false, charset: 'utf8mb4', collation: 'utf8mb4_0900_ai_ci', force: :cascade do |t|
@@ -37,8 +32,7 @@ ActiveRecord::Schema[7.1].define(version: 20_240_511_032_103) do
     t.integer 'time', limit: 2
     t.integer 'period', limit: 1
     t.bigint 'lecture_id'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
+    t.index %w[day_of_week time period user_id], name: 'idx_on_day_of_week_time_period_user_id_31d560d52f', unique: true
   end
 
   create_table 'users', charset: 'utf8mb4', collation: 'utf8mb4_0900_ai_ci', force: :cascade do |t|


### PR DESCRIPTION
Rails
　・created_at,updated_atをlectures.teachers,timetablesから削除 　・lectures,timetablesにユニークキーを付与